### PR TITLE
fix: add viewId to raw editor text input configuration

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -3,7 +3,7 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/animation.dart' show Curves;
 import 'package:flutter/cupertino.dart' show CupertinoTheme;
 import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:flutter/material.dart' show Theme;
+import 'package:flutter/material.dart' show Theme, View;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart';
 

--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -66,6 +66,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
               CupertinoTheme.maybeBrightnessOf(context) ??
               Theme.of(context).brightness,
           textCapitalization: widget.configurations.textCapitalization,
+          viewId: View.of(context).viewId,
           allowedMimeTypes:
               widget.configurations.contentInsertionConfiguration == null
                   ? const <String>[]


### PR DESCRIPTION
## What happened?
Currently, after upgrading to Flutter v3.35, Windows cannot type in `flutter_quill` due to viewId error.

## Insights
https://github.com/singerdmx/flutter-quill/pull/2579
https://github.com/singerdmx/flutter-quill/issues/2591