### PR TITLE
add forceStrutHeight = true

### DIFF
--- a/lib/src/widgets/quill/text_line.dart
+++ b/lib/src/widgets/quill/text_line.dart
@@ -168,8 +168,10 @@ class _TextLineState extends State<TextLine> {
       }
     }
     final textSpan = _getTextSpanForWholeLine();
-    final strutStyle =
-        StrutStyle.fromTextStyle(textSpan.style ?? const TextStyle());
+    final strutStyle = StrutStyle.fromTextStyle(
+      textSpan.style ?? const TextStyle(),
+      forceStrutHeight: true,
+    );
     final textAlign = _getTextAlign();
     final child = RichText(
       key: _richTextKey,


### PR DESCRIPTION
## What happen
- when we press new text on a empty line, the height changes

A **strut** defines a minimum line height used to maintain consistent vertical spacing in text.  
It is calculated from font metrics such as **ascent**, **descent**, and **leading**.

### `forceStrutHeight: false` (default)

- The line height is determined by the **tallest glyph in the line**.
- Empty lines or lines containing different characters (e.g., **ASCII, CJK, or emoji**) may have different heights.
- This can cause a **"jumping" effect** when typing, especially when starting a new line.

### `forceStrutHeight: true`

- The line height is always set to the **strut height**, calculated from the `TextStyle`.
- All lines maintain **consistent height regardless of their content**.
- This prevents height changes when typing different characters.